### PR TITLE
[Fix] 이미지 업로드 에러 해결

### DIFF
--- a/trend_gaza/src/main/java/com/ssafy/trend_gaza/Image/domain/ImageFile.java
+++ b/trend_gaza/src/main/java/com/ssafy/trend_gaza/Image/domain/ImageFile.java
@@ -44,7 +44,7 @@ public class ImageFile {
         final String filenameExtension = name.substring(name.lastIndexOf('.'));
         final String nameAndDate = name + LocalDateTime.now();
         try {
-            final MessageDigest hashAlgorithm = MessageDigest.getInstance("SHA3-256");
+            final MessageDigest hashAlgorithm = MessageDigest.getInstance("SHA-256");
             final byte[] hashBytes = hashAlgorithm.digest(nameAndDate.getBytes(StandardCharsets.UTF_8));
             return bytesToHex(hashBytes) + filenameExtension;
         } catch (final NoSuchAlgorithmException e) {


### PR DESCRIPTION
## 개요

- close #71 

## 작업사항

- 이미지 파일명을 생성하기 위해 사용한 MessageDigest 클래스에서 발생한 NoSuchAlgorithmException 해결

## 변경로직

- MessageDigest의 알고리즘 변경
