### PR TITLE
[Style] 프로필 이미지 업로드 연동

### DIFF
--- a/trend_gaza_FE/src/components/users/UserMyPage.vue
+++ b/trend_gaza_FE/src/components/users/UserMyPage.vue
@@ -177,11 +177,12 @@ const uploadRequest = (e) => {
   uploadImage(
     formData,
     ({data}) => {  
-      modifyProfileImageInfo.value.imgUrl = data[0]
-      console.log(modifyProfileImageInfo.value.imgUrl) // 잘 나옴.
+      console.log(data);
+      modifyProfileImageInfo.value.imgUrl = data.imageNames[0]
       modifyImage(
         modifyProfileImageInfo.value,
           (response) => {  
+              store.userInfo.imgUrl = modifyProfileImageInfo.value.imgUrl;
               alert("프로필 사진이 등록되었습니다!")
             },
             (error) => {


### PR DESCRIPTION
## 개요
- close #168 

## 작업사항
- 프로필 이미지를 변경 후 상태 관리 값도 변경해준다.
![image](https://github.com/SpringStudy1019/di/assets/46569105/3aa9102d-75f0-4020-a5d5-b45a55d09566)
```modifyProfileImageInfo.value.imgUrl = data.imageNames[0]```
imageName는 배열이고 0번째 인덱스에 객체 URL 값이 들어있다.

## 변경로직
- 프로필 이미지 변경 API를 호출할 때 body에 제대로 된 값을 넣어주도록 변경함
- 이미지를 업로드 후 상태관리 값을 변경해줌